### PR TITLE
Logibone loader segfault fix

### DIFF
--- a/logibone_loader/user_space/serial_fpga_loader.c
+++ b/logibone_loader/user_space/serial_fpga_loader.c
@@ -296,6 +296,11 @@ int main(int argc, char ** argv){
 	initGPIOs();
 	init_i2c(1);
 	
+	if (argc == 1) {
+		printHelp();
+		exit(EXIT_FAILURE);
+	}
+
 	//parse programm args
 	for(i = 1 ; i < argc ; ){
 		if(argv[i][0] == '-'){


### PR DESCRIPTION
Add arg checking to logibone loader, no longer segfaults when no
arguments present.
