### PR TITLE
Add gcc flag to ensure "char" is signed.

### DIFF
--- a/c/Makefile
+++ b/c/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Werror -fpic
+CFLAGS = -Wall -Werror -fpic -fsigned-char
 
 all : logipilib.o logibonelib.o
 

--- a/old/beaglebone_old/Makefile
+++ b/old/beaglebone_old/Makefile
@@ -1,7 +1,7 @@
 #Compiler to use
 CC=gcc
 #Compiler Flags
-CFLAGS=-c #-Wall
+CFLAGS=-c -fsigned-char #-Wall
 #Linker Flags
 LDFLAGS= #-lrt
 

--- a/old/logibone_loader/user_space/Makefile
+++ b/old/logibone_loader/user_space/Makefile
@@ -1,7 +1,7 @@
 #Compiler to use
 CC=gcc
 #Compiler Flags
-CFLAGS=-c #-Wall
+CFLAGS=-c -fsigned-char #-Wall
 #Linker Flags
 LDFLAGS= #-lrt
 

--- a/old/logipi_loader/Makefile
+++ b/old/logipi_loader/Makefile
@@ -1,7 +1,7 @@
 #Compiler to use
 CC=gcc
 #Compiler Flags
-CFLAGS=-c #-Wall
+CFLAGS=-c -fsigned-char #-Wall
 #Linker Flags
 LDFLAGS= #-lrt
 

--- a/old/rpi_old/Makefile
+++ b/old/rpi_old/Makefile
@@ -15,7 +15,7 @@ endif
 
 CC	= gcc
 INCLUDE	= -I/usr/local/include -I./
-CFLAGS	= $(DEBFLAGS) -Wall $(INCLUDE) -pipe
+CFLAGS	= $(DEBFLAGS) -Wall $(INCLUDE) -pipe -fsigned-char
 
 CROSS_COMPILE ?= 
 ARCH ?=

--- a/unified_loader/Makefile
+++ b/unified_loader/Makefile
@@ -6,10 +6,10 @@ PI_VER=PI2
 
 
 logipi_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
-	$(CC) $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c
+	$(CC) -fsigned-char $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c
 
 logibone_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
-	$(CC) $(LDFLAGS) -DLOGIBONE -o logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c
+	$(CC) -fsigned-char $(LDFLAGS) -DLOGIBONE -o logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c
 
 install: logi_loader
 	install logi_loader /usr/bin

--- a/wishbone_utils/Makefile
+++ b/wishbone_utils/Makefile
@@ -7,4 +7,4 @@ clean:
 	rm -f *.a *.o wb_utils
 	
 wb_utils :  wb_utils.c
-	$(CC) -o $@ wb_utils.c -llogi
+	$(CC) -fsigned-char -o $@ wb_utils.c -llogi


### PR DESCRIPTION
Some gcc builds (Arch Linux ARM for instance) default to "char" being
unsigned. This causes problems when -1 is used with something "char"
to indicate an error or an invalid value. Adding the "-fsigned-char"
flag ensures gcc will treat "char" as signed.

While this fix was primarily for the unified_loader, I added the option to all the Makefiles I was able to find.  I was not able to successfully build everything under old/, but I'm guessing that was because some tools are outdated. I was able to build c/, wishbone_utils/, and unified_loader/.  I successfully ran the updated logi_loader on a Raspberry Pi B running Arch Linux ARM, but have not tested logilib or wb_utils.