### PR TITLE
Get the unified loader working on the Raspberry Pi 5

### DIFF
--- a/unified_loader/Makefile
+++ b/unified_loader/Makefile
@@ -6,7 +6,7 @@ PI_VER=PI2
 
 
 logipi_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
-	$(CC) -fsigned-char $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c
+	$(CC) -Werror -fsigned-char $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c
 
 logibone_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
 	$(CC) -fsigned-char $(LDFLAGS) -DLOGIBONE -o logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c

--- a/unified_loader/Makefile
+++ b/unified_loader/Makefile
@@ -6,7 +6,7 @@ PI_VER=PI2
 
 
 logipi_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
-	$(CC) -Werror -fsigned-char $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c -lgpiod
+	$(CC) -Werror -fsigned-char $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c -lgpiod -ggdb
 
 logibone_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
 	$(CC) -fsigned-char $(LDFLAGS) -DLOGIBONE -o logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c

--- a/unified_loader/Makefile
+++ b/unified_loader/Makefile
@@ -1,12 +1,12 @@
 #Compiler to use
-CC=gcc
+CC=gcc -Werror
 #Linker Flags
 LDFLAGS= #-lrt
 PI_VER=PI2
 
 
 logipi_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
-	$(CC) -Werror -fsigned-char $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c
+	$(CC) -Werror -fsigned-char $(LDFLAGS) -DLOGIPI -D$(PI_VER) -o  logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c -lgpiod
 
 logibone_loader: logi_loader.c i2c_loader.c bit_bang_loader.c
 	$(CC) -fsigned-char $(LDFLAGS) -DLOGIBONE -o logi_loader logi_loader.c i2c_loader.c bit_bang_loader.c

--- a/unified_loader/bit_bang_loader.c
+++ b/unified_loader/bit_bang_loader.c
@@ -6,6 +6,9 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <linux/i2c-dev.h>
+#include <gpiod.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
 #include "bit_bang_loader.h"
 
 

--- a/unified_loader/bit_bang_loader.c
+++ b/unified_loader/bit_bang_loader.c
@@ -12,34 +12,91 @@
 #include "bit_bang_loader.h"
 
 
-#define BCM2708_PERI_BASE        0x20000000
-#define BCM2709_PERI_BASE        0x3f000000
-
-#define GPIO_OFFSET     0x200000
-
-#ifndef PI2
-#define GPIO_BASE                (BCM2708_PERI_BASE + GPIO_OFFSET) /* GPIO controller */
-#else
-#define GPIO_BASE                (BCM2709_PERI_BASE + GPIO_OFFSET)
-#endif
-
-#define PAGE_SIZE (4*1024)
-#define BLOCK_SIZE (4*1024)
-
-#define INP_GPIO(g) *(gpio+((g)/10)) &= ~(7<<(((g)%10)*3))
-#define OUT_GPIO(g) *(gpio+((g)/10)) |=  (1<<(((g)%10)*3))
-#define SET_GPIO_ALT(g,a) *(gpio+(((g)/10))) |= (((a)<=3?(a)+4:(a)==4?3:2)<<(((g)%10)*3))
-
-#define GPIO_REG(g) *(gpio+(((g)/10)))
-
-#define GPIO_SET *(gpio+7)  // sets   bits which are 1 ignores bits which are 0
-#define GPIO_CLR *(gpio+10) // clears bits which are 1 ignores bits which are 0
-#define GPIO_LEV *(gpio+13) // clears bits which are 1 ignores bits which are 0
-
-
 #define INIT 23
 #define PROG 24
 #define DONE 25
+
+#define STRINGIFY(x) #x
+#define GPIO_NAME(n) "GPIO" STRINGIFY(n)
+#define GPIO_CHIP_PATH "/dev/gpiochip0"
+#define BB_INIT_GPIO_NAME GPIO_NAME(INIT)
+#define CONSUMER "logi_loader"
+
+typedef struct gpio_line {
+    const int line_id;
+    const char *name;
+    const char *line_name;
+    int is_output;
+    struct gpiod_line *line;
+} gpio_line_type;
+
+#define GPIO_SETTINGS(which, out) {which, STRINGIFY(which), GPIO_NAME(which), out, NULL}
+
+gpio_line_type gpios[] = {
+    //{INIT, "INIT", GPIO_NAME(INIT), 0, NULL},
+    GPIO_SETTINGS(INIT, 0),
+    {DONE, "DONE", GPIO_NAME(DONE), 0, NULL},
+    {DONE, "PROG", GPIO_NAME(PROG), 1, NULL},
+};
+
+static void setup_gpio(struct gpiod_chip *chip, gpio_line_type *gpio)
+{
+    char err_buff[1000];
+    int result;
+
+    gpio->line = gpiod_chip_find_line(chip, gpio->line_name);
+    if (gpio->line == NULL) {
+        snprintf(err_buff, sizeof(err_buff), "Can't open GPIO line '%s'", gpio->name);
+        perror(err_buff);
+        exit(EXIT_FAILURE);
+    }
+
+    if (gpio->is_output) {
+        result = gpiod_line_request_output(gpio->line, CONSUMER, 0);
+    } else {
+        result = gpiod_line_request_input(gpio->line, CONSUMER);
+    }
+    if (result < 0) {
+        snprintf(err_buff, sizeof(err_buff), "Can't reserve GPIO line '%s'", gpio->name);
+        perror(err_buff);
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void cleanup_gpio(struct gpiod_chip *chip, gpio_line_type *gpio)
+{
+    (void)gpiod_line_release(gpio->line);
+    gpio->line = NULL;
+
+    (void)gpiod_chip_close(chip);
+    chip = NULL;
+}
+
+static void gpio_set(gpio_line_type *gpio, int value)
+{
+    char err_buff[1000];
+    int result = gpiod_line_set_value(gpio->line, value);
+    if (result < 0) {
+        snprintf(err_buff, sizeof(err_buff), "Can't set output value of line '%s'", gpio->name);
+        perror(err_buff);
+        exit(EXIT_FAILURE);
+
+    }
+}
+
+static int gpio_get(gpio_line_type *gpio)
+{
+    char err_buff[1000];
+    int result = gpiod_line_get_value(gpio->line);
+    if (result < 0) {
+        snprintf(err_buff, sizeof(err_buff), "Can't get input value of line '%s'", gpio->name);
+        perror(err_buff);
+        exit(EXIT_FAILURE);
+
+    }
+    return result;
+}
+
 
 void *gpio_map;
 
@@ -48,92 +105,40 @@ volatile unsigned *gpio;
 unsigned cfg_save[3] ;
 
 void clear_bb_progb(){
-	GPIO_CLR = 1<<PROG;
+	gpio_set(gpios + PROG, 0);
 }
 void set_bb_progb(){
-	GPIO_SET = 1<<PROG;
+	gpio_set(gpios + PROG, 1);
 }
 char get_bb_done(){
-	return ((GPIO_LEV >> DONE) & 0x01) ;
+	return (gpio_get(gpios + DONE)) ;
 }
 char get_bb_init(){
-	return ((GPIO_LEV >> INIT) & 0x01) ;
+	return (gpio_get(gpios + INIT)) ;
 }
 
 
+static struct gpiod_chip *chip= NULL;
 
 int init_bb_loader(){
-	unsigned int i = 0 ;
-	int mem_fd ;
-	if ((mem_fd = open("/dev/mem", O_RDWR|O_SYNC) ) < 0) {
-		printf("can't open /dev/mem \n");
-		exit(EXIT_FAILURE);
-	}
-
-	/* mmap GPIO */
-	gpio_map = mmap(
-	NULL,             //Any adddress in our space will do
-	BLOCK_SIZE,       //Map length
-	PROT_READ|PROT_WRITE,// Enable reading & writting to mapped memory
-	MAP_SHARED,       //Shared with other processes
-	mem_fd,           //File to map
-	GPIO_BASE         //Offset to GPIO peripheral
-	);
-
-	close(mem_fd); //No need to keep mem_fd open after mmap
-
-	if (gpio_map == MAP_FAILED) {
-		printf("mmap error %p\n", gpio_map);//errno also set!
-		return -1 ;
-	}
-
-	// Always use volatile pointer!
-	gpio = (volatile unsigned *)gpio_map;
-
-	for(i = 0; i < 3 ; i ++){
-		switch(i){
-			case 0:	
-				cfg_save[i] = GPIO_REG(INIT);
-				break ;
-			case 1:
-				cfg_save[i] = GPIO_REG(PROG);
-				break ;
-			case 2:
-				cfg_save[i] = GPIO_REG(DONE);
-				break ;
-			default: 
-				break ;
-		};
-		
-	}
-
-	INP_GPIO(INIT);
-	INP_GPIO(PROG);
-	INP_GPIO(DONE);	
-
-	OUT_GPIO(PROG);
+    chip = gpiod_chip_open(GPIO_CHIP_PATH);
+    if (chip == NULL) {
+        perror("Can't open GPIO chip device " GPIO_CHIP_PATH);
+        exit(EXIT_FAILURE);
+    }
+    for (int i = 0; i < sizeof(gpios)/sizeof(gpio_line_type); i++) {
+        setup_gpio(chip, gpios + i);
+        printf("Set up GPIO line %i\n", i);
+    }
 	return 0 ;
 }
 
 
 void close_bb_loader(){
-	unsigned int i ;
-	for(i = 0; i < 3 ; i ++){
-		switch(i){
-			case 0:	
-				GPIO_REG(INIT) = cfg_save[i] ;
-				break ;
-			case 1:
-				GPIO_REG(PROG) = cfg_save[i] ;
-				break ;
-			case 2:
-				GPIO_REG(DONE) = cfg_save[i] ;
-				break ;
-			default: 
-				break ;
-		};
-		
-	}
+    for (int i = 0; i < sizeof(gpios)/sizeof(gpio_line_type); i++) {
+        cleanup_gpio(chip, gpios + i);
+        printf("Cleaned up GPIO line %i\n", i);
+    }
 }
 
 

--- a/unified_loader/bit_bang_loader.c
+++ b/unified_loader/bit_bang_loader.c
@@ -36,8 +36,10 @@ gpio_line_type gpios[] = {
     //{INIT, "INIT", GPIO_NAME(INIT), 0, NULL},
     GPIO_SETTINGS(INIT, 0),
     {DONE, "DONE", GPIO_NAME(DONE), 0, NULL},
-    {DONE, "PROG", GPIO_NAME(PROG), 1, NULL},
+    {PROG, "PROG", GPIO_NAME(PROG), 1, NULL},
 };
+
+gpio_line_type *gpio_lines[40] = {};
 
 static void setup_gpio(struct gpiod_chip *chip, gpio_line_type *gpio)
 {
@@ -61,15 +63,15 @@ static void setup_gpio(struct gpiod_chip *chip, gpio_line_type *gpio)
         perror(err_buff);
         exit(EXIT_FAILURE);
     }
+    gpio_lines[gpio->line_id] = gpio;
 }
 
 static void cleanup_gpio(struct gpiod_chip *chip, gpio_line_type *gpio)
 {
+    gpio_lines[gpio->line_id] = NULL;
+
     (void)gpiod_line_release(gpio->line);
     gpio->line = NULL;
-
-    (void)gpiod_chip_close(chip);
-    chip = NULL;
 }
 
 static void gpio_set(gpio_line_type *gpio, int value)
@@ -105,16 +107,16 @@ volatile unsigned *gpio;
 unsigned cfg_save[3] ;
 
 void clear_bb_progb(){
-	gpio_set(gpios + PROG, 0);
+	gpio_set(gpio_lines[PROG], 0);
 }
 void set_bb_progb(){
-	gpio_set(gpios + PROG, 1);
+	gpio_set(gpio_lines[PROG], 1);
 }
 char get_bb_done(){
-	return (gpio_get(gpios + DONE)) ;
+	return (gpio_get(gpio_lines[DONE])) ;
 }
 char get_bb_init(){
-	return (gpio_get(gpios + INIT)) ;
+	return (gpio_get(gpio_lines[INIT])) ;
 }
 
 
@@ -139,6 +141,9 @@ void close_bb_loader(){
         cleanup_gpio(chip, gpios + i);
         printf("Cleaned up GPIO line %i\n", i);
     }
+
+    (void)gpiod_chip_close(chip);
+    chip = NULL;
 }
 
 

--- a/unified_loader/i2c_loader.c
+++ b/unified_loader/i2c_loader.c
@@ -4,8 +4,10 @@
 #include <sys/stat.h>
 #include <stdint.h>
 #include <sys/mman.h>
+#include <sys/ioctl.h>
 #include <fcntl.h>
 #include <linux/i2c-dev.h>
+#include <unistd.h>
 #include "i2c_loader.h"
 
 
@@ -40,7 +42,7 @@ static inline unsigned char i2c_get_pin(struct i2c_loader_struct * ldr_ptr, unsi
 	unsigned char i2c_buffer;
 
 	if (ioctl(i2c_fd, I2C_SLAVE, ldr_ptr->expander_address) < 0) {
-		return ;
+		return 0;
 	}
 		
 	i2c_buffer = ldr_ptr->expander_in;

--- a/unified_loader/logi_loader.c
+++ b/unified_loader/logi_loader.c
@@ -12,6 +12,7 @@
 #include <linux/spi/spidev.h>
 #include <string.h> 
 #include <math.h>
+#include <unistd.h>
 #include "logi_loader.h"
 #include "i2c_loader.h"
 #include "bit_bang_loader.h"

--- a/unified_loader/logi_loader.c
+++ b/unified_loader/logi_loader.c
@@ -139,19 +139,19 @@ int init_spi(char * path){
 	int ret ;
 	spi_fd = open(path, O_RDWR);
 	if (spi_fd < 0){
-		printf("can't open SPI spi_device\n");
+		perror("can't open SPI spi_device");
 		return -1 ;
 	}
 
 	ret = ioctl(spi_fd, SPI_IOC_WR_MODE, &spi_mode);
 	if (ret == -1){
-		printf("can't set spi mode \n");
+		perror("can't set spi mode");
 		return -1 ;
 	}
 
 	ret = ioctl(spi_fd, SPI_IOC_RD_MODE, &spi_mode);
 	if (ret == -1){
-		printf("can't get spi mode \n ");
+		perror("can't get spi mode");
 		return -1 ;
 	}
 
@@ -160,13 +160,13 @@ int init_spi(char * path){
 	 */
 	ret = ioctl(spi_fd, SPI_IOC_WR_BITS_PER_WORD, &spi_bits);
 	if (ret == -1){
-		printf("can't set bits per word \n");
+		perror("can't set bits per word");
 		return -1 ;
 	}
 
 	ret = ioctl(spi_fd, SPI_IOC_RD_BITS_PER_WORD, &spi_bits);
 	if (ret == -1){
-		printf("can't get bits per word \n");
+		perror("can't get bits per word");
 		return -1 ;
 	}
 
@@ -175,13 +175,13 @@ int init_spi(char * path){
 	 */
 	ret = ioctl(spi_fd, SPI_IOC_WR_MAX_SPEED_HZ, &spi_speed);
 	if (ret == -1){
-		printf("can't set max speed hz \n");
+		perror("can't set max speed hz");
 		return -1 ;
 	}
 
 	ret = ioctl(spi_fd, SPI_IOC_RD_MAX_SPEED_HZ, &spi_speed);
 	if (ret == -1){
-		printf("can't get max speed hz \n");
+		perror("can't get max speed hz");
 		return -1 ;
 	}
 	

--- a/unified_loader/logi_loader.c
+++ b/unified_loader/logi_loader.c
@@ -361,7 +361,7 @@ int main(int argc, char ** argv){
 	}
 	*/
 	fr = fopen (argv[i], "rb");  /* open the file for reading bytes*/
-	if(fr < 0){
+	if(!fr){
 		printf("cannot open file %s \n", argv[1]);
 		return -1 ;	
 	}

--- a/unified_loader/logi_loader.c
+++ b/unified_loader/logi_loader.c
@@ -380,5 +380,5 @@ int main(int argc, char ** argv){
 	fclose(fr);
 	close_loader();
 	close(spi_fd);
-	return 1;
+	return 0;
 }


### PR DESCRIPTION
This changeset modifies the unified loader for Logi-Pi to use `libgpiod`. This should mean that it works on all Raspberry Pi models, from the first to the latest. (I have only tested it on the Pi 5, however.)

The changes also improve error handling and fix a few minor bugs.
